### PR TITLE
Implement new behaviour for OnDriverDistruction.

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -168,6 +168,11 @@ typedef std::set<mobile_apis::VehicleDataType::eType> VehicleInfoSubscriptions;
  */
 typedef std::set<mobile_apis::ButtonName::eType> ButtonSubscriptions;
 
+/**
+ * @breif Colelction for the mobile command smart object.
+ */
+typedef std::vector<smart_objects::SmartObjectSPtr> MobileMessageQueue;
+
 class DynamicApplicationData {
  public:
   virtual ~DynamicApplicationData() {}
@@ -785,6 +790,23 @@ class Application : public virtual InitialApplicationData,
    * @return free app space.
    */
   virtual uint32_t GetAvailableDiskSpace() = 0;
+
+  /**
+   * @breif Allows to save mobile's command smart object in order to perform
+   * this command later.
+   * @param mobile_message the message smart_object.
+   */
+  virtual void PushMobileMessage(
+      smart_objects::SmartObjectSPtr mobile_message) = 0;
+
+  /**
+   * @breif Allows to obtain the whole list of pending commands in order to
+   * process them.
+   * @param mobile_message the messages array which is filled by the method.
+   * @Note After the method return the data internal messages array will be
+   * cleared.
+   */
+  virtual void SwapMobileMessageQueue(MobileMessageQueue& mobile_messages) = 0;
 
 #ifdef SDL_REMOTE_CONTROL
   /**

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -341,6 +341,23 @@ class ApplicationImpl : public virtual Application,
   AppExtensionPtr QueryInterface(AppExtensionUID uid) OVERRIDE;
 #endif
 
+  /**
+   * @breif Allows to save mobile's command smart object in order
+   * to perform this command later.
+   * @param mobile_message the message smart_object.
+   */
+  void PushMobileMessage(
+      smart_objects::SmartObjectSPtr mobile_message) OVERRIDE;
+
+  /**
+   * @breif Allows to obtain the whole list of pending commands in order to
+   * process them.
+   * @param mobile_message the messages array which is filled by the method.
+   * @Note After the method return the data internal messages array will be
+   * cleared.
+   */
+  void SwapMobileMessageQueue(MobileMessageQueue& mobile_messages) OVERRIDE;
+
  protected:
   /**
    * @brief Clean up application folder. Persistent files will stay
@@ -467,6 +484,10 @@ class ApplicationImpl : public virtual Application,
   sync_primitives::Lock button_lock_;
   std::string folder_name_;
   ApplicationManager& application_manager_;
+
+  sync_primitives::Lock mobile_message_lock_;
+  MobileMessageQueue mobile_message_queue_;
+
   DISALLOW_COPY_AND_ASSIGN(ApplicationImpl);
 };
 

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -1089,4 +1089,17 @@ void ApplicationImpl::RemoveExtensions() {
 }
 #endif  // SDL_REMOTE_CONTROL
 
+void ApplicationImpl::PushMobileMessage(
+    smart_objects::SmartObjectSPtr mobile_message) {
+  sync_primitives::AutoLock lock(mobile_message_lock_);
+  mobile_message_queue_.push_back(mobile_message);
+}
+
+void ApplicationImpl::SwapMobileMessageQueue(
+    MobileMessageQueue& mobile_messages) {
+  sync_primitives::AutoLock lock(mobile_message_lock_);
+  mobile_messages.clear();
+  mobile_messages.swap(mobile_message_queue_);
+}
+
 }  // namespace application_manager

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -110,7 +110,8 @@ ApplicationManagerImpl::ApplicationManagerImpl(
     : settings_(am_settings)
     , applications_list_lock_(true)
     , audio_pass_thru_active_(false)
-    , is_distracting_driver_(false)
+    , distracting_driver_state_(
+          hmi_apis::Common_DriverDistractionState::INVALID_ENUM)
     , is_vr_session_strated_(false)
     , hmi_cooperating_(false)
     , is_all_apps_allowed_(true)
@@ -607,6 +608,8 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
     const std::string& bundle_id = app_info[strings::bundle_id].asString();
     application->set_bundle_id(bundle_id);
   }
+  PutDriverDistractionMessageToPostponed(application);
+
   // Stops timer of saving data to resumption in order to
   // doesn't erase data from resumption storage.
   // Timer will be started after hmi level resumption.
@@ -775,8 +778,9 @@ bool ApplicationManagerImpl::EndAudioPassThrough() {
   }
 }
 
-void ApplicationManagerImpl::set_driver_distraction(const bool is_distracting) {
-  is_distracting_driver_ = is_distracting;
+void ApplicationManagerImpl::set_distracting_driver_state(
+    const hmi_apis::Common_DriverDistractionState::eType state) {
+  distracting_driver_state_ = state;
 }
 
 void ApplicationManagerImpl::set_vr_session_started(const bool state) {
@@ -1694,7 +1698,6 @@ bool ApplicationManagerImpl::ManageMobileCommand(
     const commands::MessageSharedPtr message,
     commands::Command::CommandOrigin origin) {
   LOG4CXX_AUTO_TRACE(logger_);
-
   if (!message) {
     LOG4CXX_WARN(logger_, "Null-pointer message received.");
     return false;
@@ -3405,6 +3408,45 @@ void ApplicationManagerImpl::OnHMILevelChanged(
     mobile_apis::HMILevel::eType from,
     mobile_apis::HMILevel::eType to) {
   LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_INFO(logger_, "HMI level from = " << from << " to = " << to);
+  ProcessPostponedMessages(app_id);
+  ProcessNaviApp(app_id, from, to);
+}
+
+void ApplicationManagerImpl::ProcessPostponedMessages(const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  ApplicationSharedPtr app = application(app_id);
+  if (!app) {
+    LOG4CXX_WARN(logger_, "The app with id: " << app_id << " is not exists");
+    return;
+  }
+  MobileMessageQueue messages;
+  app->SwapMobileMessageQueue(messages);
+  std::for_each(
+      messages.begin(),
+      messages.end(),
+      [this, &app](smart_objects::SmartObjectSPtr message) {
+        const std::string functionID = MessageHelper::StringifiedFunctionID(
+            static_cast<mobile_apis::FunctionID::eType>(
+                (*message)[strings::params][strings::function_id].asUInt()));
+        const RPCParams params;
+        const mobile_apis::Result::eType check_result =
+            CheckPolicyPermissions(app, functionID, params);
+        if (check_result == mobile_api::Result::SUCCESS) {
+          ManageMobileCommand(message,
+                              commands::Command::CommandOrigin::ORIGIN_SDL);
+        } else {
+          app->PushMobileMessage(message);
+        }
+
+      });
+}
+
+void ApplicationManagerImpl::ProcessNaviApp(
+    const uint32_t app_id,
+    const mobile_apis::HMILevel::eType from,
+    const mobile_apis::HMILevel::eType to) {
   using namespace mobile_apis::HMILevel;
   using namespace helpers;
 
@@ -3887,6 +3929,32 @@ void ApplicationManagerImpl::OnPTUFinished(const bool ptu_result) {
   plugin_manager_.OnPolicyEvent(
       functional_modules::PolicyEvent::kApplicationPolicyUpdated);
 #endif  // SDL_REMOTE_CONTROL
+}
+
+void ApplicationManagerImpl::PutDriverDistractionMessageToPostponed(
+    ApplicationSharedPtr application) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (hmi_apis::Common_DriverDistractionState::INVALID_ENUM ==
+      distracting_driver_state()) {
+    LOG4CXX_INFO(logger_, "DriverDistractionState is INVALID_ENUM");
+    return;
+  }
+  smart_objects::SmartObjectSPtr on_driver_distraction =
+      utils::MakeShared<smart_objects::SmartObject>();
+
+  if (!on_driver_distraction) {
+    LOG4CXX_ERROR(logger_, "NULL pointer");
+    return;
+  }
+  (*on_driver_distraction)[strings::params][strings::message_type] =
+      static_cast<int32_t>(application_manager::MessageType::kNotification);
+  (*on_driver_distraction)[strings::params][strings::function_id] =
+      mobile_api::FunctionID::OnDriverDistractionID;
+  (*on_driver_distraction)[strings::msg_params][mobile_notification::state] =
+      distracting_driver_state();
+  (*on_driver_distraction)[strings::params][strings::connection_key] =
+      application->app_id();
+  application->PushMobileMessage(on_driver_distraction);
 }
 
 protocol_handler::MajorProtocolVersion

--- a/src/components/application_manager/src/commands/hmi/on_driver_distraction_notification.cc
+++ b/src/components/application_manager/src/commands/hmi/on_driver_distraction_notification.cc
@@ -34,14 +34,62 @@
 #include "application_manager/commands/hmi/on_driver_distraction_notification.h"
 
 #include "application_manager/application_impl.h"
+#include "application_manager/message_helper.h"
 #include "interfaces/MOBILE_API.h"
 #include "interfaces/HMI_API.h"
+#include "utils/make_shared.h"
 
 namespace application_manager {
 
 namespace commands {
 
 namespace hmi {
+
+namespace {
+struct ApplicationProcessor {
+  ApplicationProcessor(OnDriverDistractionNotification& command,
+                       smart_objects::SmartObjectSPtr on_driver_distraction_so,
+                       ApplicationManager& application_manager)
+      : command_(command)
+      , on_driver_distraction_so_(on_driver_distraction_so)
+      , application_manager_(application_manager)
+      , stringified_functionID_(MessageHelper::StringifiedFunctionID(
+            mobile_api::FunctionID::OnDriverDistractionID)) {}
+
+  void operator()(ApplicationSharedPtr application) {
+    if (application) {
+      (*on_driver_distraction_so_)[strings::params][strings::connection_key] =
+          application->app_id();
+      const RPCParams params;
+      policy::CheckPermissionResult result;
+      application_manager_.GetPolicyHandler().CheckPermissions(
+          application, stringified_functionID_, params, result);
+      if (result.hmi_level_permitted != policy::kRpcAllowed) {
+        MobileMessageQueue messages;
+        application->SwapMobileMessageQueue(messages);
+        messages.erase(
+            std::remove_if(
+                messages.begin(),
+                messages.end(),
+                [this](smart_objects::SmartObjectSPtr message) {
+                  return (*message)[strings::params][strings::function_id]
+                             .asString() == stringified_functionID_;
+                }),
+            messages.end());
+        application->PushMobileMessage(on_driver_distraction_so_);
+        return;
+      }
+      command_.SendNotificationToMobile(on_driver_distraction_so_);
+    }
+  }
+
+ private:
+  OnDriverDistractionNotification& command_;
+  smart_objects::SmartObjectSPtr on_driver_distraction_so_;
+  ApplicationManager& application_manager_;
+  std::string stringified_functionID_;
+};
+}
 
 OnDriverDistractionNotification::OnDriverDistractionNotification(
     const MessageSharedPtr& message, ApplicationManager& application_manager)
@@ -51,38 +99,31 @@ OnDriverDistractionNotification::~OnDriverDistractionNotification() {}
 
 void OnDriverDistractionNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-
   const hmi_apis::Common_DriverDistractionState::eType state =
       static_cast<hmi_apis::Common_DriverDistractionState::eType>(
           (*message_)[strings::msg_params][hmi_notification::state].asInt());
-  application_manager_.set_driver_distraction(state);
+  application_manager_.set_distracting_driver_state(state);
 
   smart_objects::SmartObjectSPtr on_driver_distraction =
-      new smart_objects::SmartObject();
+      utils::MakeShared<smart_objects::SmartObject>();
 
   if (!on_driver_distraction) {
     LOG4CXX_ERROR(logger_, "NULL pointer");
     return;
   }
-
   (*on_driver_distraction)[strings::params][strings::function_id] =
       mobile_api::FunctionID::OnDriverDistractionID;
-
+  (*on_driver_distraction)[strings::params][strings::message_type] =
+      static_cast<int32_t>(application_manager::MessageType::kNotification);
   (*on_driver_distraction)[strings::msg_params][mobile_notification::state] =
       state;
 
   const ApplicationSet applications =
       application_manager_.applications().GetData();
 
-  ApplicationSetConstIt it = applications.begin();
-  for (; applications.end() != it; ++it) {
-    const ApplicationSharedPtr app = *it;
-    if (app) {
-      (*on_driver_distraction)[strings::params][strings::connection_key] =
-          app->app_id();
-      SendNotificationToMobile(on_driver_distraction);
-    }
-  }
+  ApplicationProcessor app_processor(
+      *this, on_driver_distraction, application_manager_);
+  std::for_each(applications.begin(), applications.end(), app_processor);
 }
 
 }  // namespace hmi

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -784,6 +784,27 @@ TEST_F(ApplicationImplTest, StopStreaming_StreamingApproved) {
   EXPECT_FALSE(app_impl->audio_streaming_approved());
 }
 
+TEST_F(ApplicationImplTest, PushPopMobileMessage) {
+  smart_objects::SmartObjectSPtr on_driver_distraction =
+      utils::MakeShared<smart_objects::SmartObject>();
+
+  (*on_driver_distraction)[strings::params][strings::function_id] =
+      mobile_api::FunctionID::OnDriverDistractionID;
+
+  (*on_driver_distraction)[strings::msg_params][mobile_notification::state] = 0;
+
+  app_impl->PushMobileMessage(on_driver_distraction);
+  app_impl->PushMobileMessage(on_driver_distraction);
+
+  MobileMessageQueue messages;
+  app_impl->SwapMobileMessageQueue(messages);
+
+  EXPECT_EQ(messages.size(), 2u);
+
+  app_impl->SwapMobileMessageQueue(messages);
+  EXPECT_EQ(messages.size(), 0u);
+}
+
 }  // namespace application_manager_test
 }  // namespace components
 }  // namespace test

--- a/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
+++ b/src/components/application_manager/test/commands/hmi/hmi_notifications/hmi_notifications_test.cc
@@ -180,6 +180,11 @@ ACTION_P(GetEventId, event_id) {
 ACTION_P(GetArg, arg) {
   *arg = arg0;
 }
+
+ACTION_P(GetArg3, result) {
+  arg3 = *result;
+}
+
 ACTION_P2(GetConnectIdPermissionConsent, connect_id, consent) {
   *connect_id = arg0;
   std::vector<policy::FunctionalGroupPermission>::const_iterator it =
@@ -1896,7 +1901,7 @@ TEST_F(HMICommandsNotificationsTest, OnDriverDistractionNotificationEmptyData) {
   utils::SharedPtr<Command> command =
       CreateCommand<hmi::OnDriverDistractionNotification>(message);
 
-  EXPECT_CALL(app_mngr_, set_driver_distraction(state));
+  EXPECT_CALL(app_mngr_, set_distracting_driver_state(state));
   EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
 
   EXPECT_CALL(app_mngr_, ManageMobileCommand(_, _)).Times(0);
@@ -1931,12 +1936,19 @@ TEST_F(HMICommandsNotificationsTest, OnDriverDistractionNotificationValidApp) {
       CreateCommand<hmi::OnDriverDistractionNotification>(message);
 
   application_set_.insert(app_);
-
   EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(applications_));
+  policy::CheckPermissionResult result;
+  result.hmi_level_permitted = policy::kRpcAllowed;
+  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+      .WillOnce(ReturnRef(policy_interface_));
+  EXPECT_CALL(policy_interface_, CheckPermissions(_, _, _, _))
+      .WillOnce(GetArg3(&result));
   EXPECT_CALL(app_mngr_,
               ManageMobileCommand(_, Command::CommandOrigin::ORIGIN_SDL))
       .WillOnce(GetMessage(message));
+  ;
   EXPECT_CALL(*app_ptr_, app_id()).WillRepeatedly(Return(kAppId_));
+
   command->Run();
   EXPECT_EQ(
       static_cast<int32_t>(am::mobile_api::FunctionID::OnDriverDistractionID),

--- a/src/components/application_manager/test/commands/hmi/on_driver_distraction_notification_test.cc
+++ b/src/components/application_manager/test/commands/hmi/on_driver_distraction_notification_test.cc
@@ -43,6 +43,7 @@
 #include "commands/commands_test.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_application_manager.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
 #include "hmi/on_driver_distraction_notification.h"
 #include "interfaces/MOBILE_API.h"
 
@@ -68,6 +69,7 @@ class HMIOnDriverDistractionNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   ::sync_primitives::Lock app_set_lock_;
+  policy_test::MockPolicyHandlerInterface mock_policy_handler_interface_;
 };
 
 MATCHER_P2(CheckNotificationParams, function_id, state, "") {
@@ -83,16 +85,52 @@ MATCHER_P2(CheckNotificationParams, function_id, state, "") {
   return is_function_id_matched && is_state_matched;
 }
 
-TEST_F(HMIOnDriverDistractionNotificationTest,
-       Run_SendNotificationToMobile_SUCCESS) {
-  MessageSharedPtr msg = CreateMessage();
+ACTION_P(GetArg3, result) {
+  arg3 = *result;
+}
+
+TEST_F(HMIOnDriverDistractionNotificationTest, Run_PushMobileMessage_SUCCESS) {
   const hmi_apis::Common_DriverDistractionState::eType state =
       hmi_apis::Common_DriverDistractionState::DD_ON;
-  (*msg)[am::strings::msg_params][am::hmi_notification::state] = state;
+  MessageSharedPtr commands_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*commands_msg)[am::strings::msg_params][am::hmi_notification::state] = state;
 
-  NotificationPtr command(CreateCommand<OnDriverDistractionNotification>(msg));
+  NotificationPtr command(
+      CreateCommand<OnDriverDistractionNotification>(commands_msg));
 
-  EXPECT_CALL(app_mngr_, set_driver_distraction(state));
+  EXPECT_CALL(app_mngr_, set_distracting_driver_state(Eq(state)));
+
+  MockAppPtr mock_app = CreateMockApp();
+  am::ApplicationSet app_set;
+  app_set.insert(mock_app);
+
+  DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
+  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  policy::CheckPermissionResult result;
+  result.hmi_level_permitted = policy::kRpcDisallowed;
+  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+      .WillOnce(ReturnRef(mock_policy_handler_interface_));
+  EXPECT_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
+      .WillOnce(GetArg3(&result));
+
+  EXPECT_CALL(*mock_app,
+              PushMobileMessage(CheckNotificationParams(
+                  am::mobile_api::FunctionID::OnDriverDistractionID, state)));
+
+  command->Run();
+}
+
+TEST_F(HMIOnDriverDistractionNotificationTest,
+       Run_SendNotificationToMobile_SUCCESS) {
+  const hmi_apis::Common_DriverDistractionState::eType state =
+      hmi_apis::Common_DriverDistractionState::DD_ON;
+  MessageSharedPtr commands_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*commands_msg)[am::strings::msg_params][am::hmi_notification::state] = state;
+
+  NotificationPtr command(
+      CreateCommand<OnDriverDistractionNotification>(commands_msg));
+
+  EXPECT_CALL(app_mngr_, set_distracting_driver_state(Eq(state)));
 
   MockAppPtr mock_app = CreateMockApp();
   am::ApplicationSet app_set;
@@ -101,9 +139,12 @@ TEST_F(HMIOnDriverDistractionNotificationTest,
   DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
   EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
 
-  const uint32_t app_id = 1u;
-  EXPECT_CALL(*mock_app, app_id()).WillOnce(Return(app_id));
-
+  policy::CheckPermissionResult result;
+  result.hmi_level_permitted = policy::kRpcAllowed;
+  EXPECT_CALL(app_mngr_, GetPolicyHandler())
+      .WillOnce(ReturnRef(mock_policy_handler_interface_));
+  EXPECT_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
+      .WillOnce(GetArg3(&result));
   EXPECT_CALL(app_mngr_,
               ManageMobileCommand(
                   CheckNotificationParams(

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -288,6 +288,10 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(IsRegistered, bool());
   MOCK_CONST_METHOD0(SchemaUrl, std::string());
   MOCK_CONST_METHOD0(PackageName, std::string());
+  MOCK_METHOD1(PushMobileMessage, void(smart_objects::SmartObjectSPtr message));
+  MOCK_METHOD1(
+      SwapMobileMessageQueue,
+      void(::application_manager::MobileMessageQueue& mobile_messages));
 
 #ifdef SDL_REMOTE_CONTROL
   MOCK_METHOD1(

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -424,7 +424,8 @@ class ApplicationManager {
    *
    * @param state New state to be set
    */
-  virtual void set_driver_distraction(bool is_distracting) = 0;
+  virtual void set_distracting_driver_state(
+      const hmi_apis::Common_DriverDistractionState::eType state) = 0;
 
   /*
    * @brief Starts audio pass thru thread

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -187,7 +187,9 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                                  const std::string& file_name,
                                  const int64_t offset));
   MOCK_METHOD1(SetAllAppsAllowed, void(const bool allowed));
-  MOCK_METHOD1(set_driver_distraction, void(bool is_distracting));
+  MOCK_METHOD1(
+      set_distracting_driver_state,
+      void(const hmi_apis::Common_DriverDistractionState::eType state));
   MOCK_METHOD6(StartAudioPassThruThread,
                void(int32_t session_key,
                     int32_t correlation_id,

--- a/src/components/remote_control/test/include/mock_application.h
+++ b/src/components/remote_control/test/include/mock_application.h
@@ -298,6 +298,10 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(IsRegistered, bool());
   MOCK_CONST_METHOD0(SchemaUrl, std::string());
   MOCK_CONST_METHOD0(PackageName, std::string());
+  MOCK_METHOD1(PushMobileMessage, void(smart_objects::SmartObjectSPtr message));
+  MOCK_METHOD1(
+      SwapMobileMessageQueue,
+      void(::application_manager::MobileMessageQueue& mobile_messages));
 
 #ifdef SDL_REMOTE_CONTROL
   MOCK_METHOD1(


### PR DESCRIPTION
According to the new behavior SDL has to postpone OnDriverDistruction
for the application which are in NONE hmi level and send this
notification once device change hmi level in some other hmi level.
Fixes https://github.com/SmartDeviceLink/sdl_core/issues/1881