### PR TITLE
Fix commands UTs

### DIFF
--- a/src/components/application_manager/test/commands/hmi/get_urls_test.cc
+++ b/src/components/application_manager/test/commands/hmi/get_urls_test.cc
@@ -107,6 +107,7 @@ class GetUrlsTest : public CommandRequestTest<CommandsTestMocks::kIsNice> {
 
 TEST_F(GetUrlsTest, RUN_SUCCESS) {
   EXPECT_CALL(mock_policy_handler_, PolicyEnabled()).WillOnce(Return(true));
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
 
   request_command_->Run();
 }
@@ -328,6 +329,7 @@ TEST_F(GetUrlsTest, ProcessServiceURLs_PolicyDefaultId_SUCCESS) {
   MockAppPtr mock_app = CreateMockApp();
   EXPECT_CALL(app_mngr_, application_by_policy_id(_))
       .WillOnce(Return(mock_app));
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
   request_command_->Run();
 
   EXPECT_FALSE((*command_msg_)[am::strings::msg_params].keyExists(

--- a/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -245,6 +245,7 @@ TEST_F(SDLActivateAppRequestTest, DevicesAppsEmpty_SUCCESS) {
 
   EXPECT_CALL(app_mngr_, state_controller())
       .WillOnce(ReturnRef(mock_state_controller_));
+  EXPECT_CALL(app_mngr_, GetRPCService()).WillOnce(ReturnRef(rpc_service_));
   EXPECT_CALL(mock_state_controller_,
               IsStateActive(am::HmiState::StateID::STATE_ID_DEACTIVATE_HMI))
       .WillOnce(Return(false));

--- a/src/components/application_manager/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/alert_request_test.cc
@@ -244,6 +244,7 @@ TEST_F(AlertRequestTest, OnEvent_UI_HmiSendSuccess_UNSUPPORTED_RESOURCE) {
       hmi_apis::Common_Result::SUCCESS;
   Event event_vr(hmi_apis::FunctionID::TTS_Speak);
   event_vr.set_smart_object(*msg_tts);
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
 
   command->on_event(event_vr);
 
@@ -251,7 +252,6 @@ TEST_F(AlertRequestTest, OnEvent_UI_HmiSendSuccess_UNSUPPORTED_RESOURCE) {
   event.set_smart_object(*msg);
 
   MessageSharedPtr ui_command_result;
-  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
   EXPECT_CALL(
       rpc_service_,
       ManageMobileCommand(_, am::commands::Command::CommandOrigin::ORIGIN_SDL))

--- a/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -262,6 +262,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_InvalidApp_UNSUCCESS) {
   MockAppPtr invalid_app;
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(invalid_app));
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
 
   command_->Run();
 }
@@ -276,6 +277,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_VerifyImageFail_UNSUCCESS) {
   EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::INVALID_DATA));
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
 
   command_->Run();
 }
@@ -298,6 +300,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_FindChoiceSetFail_UNSUCCESS) {
   EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(invalid_choice_set_id));
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
   command_->Run();
 }
 
@@ -331,6 +334,8 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   EXPECT_CALL(*mock_app_, FindChoiceSet(kChoiceSetId))
       .WillOnce(Return(choice_set_id));
 
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
+
   EXPECT_CALL(app_mngr_, GenerateGrammarID()).Times(0);
   command_->Run();
 }
@@ -363,6 +368,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
 
   EXPECT_CALL(mock_message_helper_, VerifyImage(_, _, _))
       .WillRepeatedly(Return(mobile_apis::Result::SUCCESS));
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
 
   if ((*message_)[am::strings::msg_params][am::strings::choice_set][0]
           .keyExists(am::strings::menu_name)) {
@@ -443,6 +449,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
       .Times(AtLeast(2))
       .WillOnce(Return(kConnectionKey))
       .WillOnce(Return(kConnectionKey));
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
   command_->Run();
 }
 
@@ -477,6 +484,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
       .WillOnce(Return(choice_set_id));
 
   EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
   command_->Run();
 }
 
@@ -526,6 +534,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnEvent_ValidVrNoError_SUCCESS) {
   EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
   command_->Run();
 
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
@@ -559,6 +568,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
   command_->Run();
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _)).Times(0);
@@ -593,6 +603,9 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
+  EXPECT_CALL(app_mngr_, GetRPCService())
+      .Times(3)
+      .WillRepeatedly(ReturnRef(rpc_service_));
   command_->Run();
 
   FillMessageFieldsItem2(message_);
@@ -640,6 +653,9 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
+  EXPECT_CALL(app_mngr_, GetRPCService())
+      .Times(3)
+      .WillRepeatedly(ReturnRef(rpc_service_));
   command_->Run();
 
   FillMessageFieldsItem2(message_);
@@ -682,6 +698,9 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeOut_InvalidApp_UNSUCCESS) {
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
   ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
+  EXPECT_CALL(app_mngr_, GetRPCService())
+      .Times(3)
+      .WillRepeatedly(ReturnRef(rpc_service_));
   command_->Run();
 
   FillMessageFieldsItem2(message_);
@@ -726,6 +745,9 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
       .WillOnce(Return(choice_set_id));
   EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _));
 
+  EXPECT_CALL(app_mngr_, GetRPCService())
+      .Times(6)
+      .WillRepeatedly(ReturnRef(rpc_service_));
   command_->Run();
 
   FillMessageFieldsItem2(message_);
@@ -796,6 +818,9 @@ TEST_F(CreateInteractionChoiceSetRequestTest, Run_ErrorFromHmiFalse_UNSUCCESS) {
   EXPECT_CALL(*mock_app_, AddChoiceSet(kChoiceSetId, _)).Times(2);
   ON_CALL(app_mngr_, GetNextHMICorrelationID())
       .WillByDefault(Return(kCorrelationId));
+  EXPECT_CALL(app_mngr_, GetRPCService())
+      .Times(3)
+      .WillRepeatedly(ReturnRef(rpc_service_));
   command_->Run();
 
   FillMessageFieldsItem2(message_);

--- a/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
+++ b/src/components/application_manager/test/commands/mobile/delete_interaction_choice_set_test.cc
@@ -194,19 +194,22 @@ TEST_F(DeleteInteractionChoiceSetRequestTest,
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillRepeatedly(Return(app_));
 
-  InSequence seq;
+  {
+    InSequence seq;
 
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
-      .WillOnce(Return(choice_set_id));
-  EXPECT_CALL(*app_, is_perform_interaction_active()).WillOnce(Return(false));
-  EXPECT_CALL(*app_, performinteraction_choice_set_map()).Times(0);
+    EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+        .WillOnce(Return(choice_set_id));
+    EXPECT_CALL(*app_, is_perform_interaction_active()).WillOnce(Return(false));
+    EXPECT_CALL(*app_, performinteraction_choice_set_map()).Times(0);
 
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
-      .WillOnce(Return(invalid_choice_set_id));
+    EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+        .WillOnce(Return(invalid_choice_set_id));
 
-  EXPECT_CALL(*app_, app_id()).WillOnce(Return(kConnectionKey));
-  EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
-  EXPECT_CALL(*app_, UpdateHash());
+    EXPECT_CALL(*app_, app_id()).WillOnce(Return(kConnectionKey));
+    EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
+    EXPECT_CALL(*app_, UpdateHash());
+  }
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
 
   DeleteInteractionChoiceSetRequestPtr command =
       CreateCommand<DeleteInteractionChoiceSetRequest>(message_);
@@ -229,21 +232,28 @@ TEST_F(DeleteInteractionChoiceSetRequestTest, Run_SendVrDeleteCommand_SUCCESS) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillRepeatedly(Return(app_));
 
-  InSequence seq;
+  {
+    InSequence seq;
 
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
-      .WillOnce(Return(choice_set_id));
-  EXPECT_CALL(*app_, is_perform_interaction_active()).WillOnce(Return(false));
-  EXPECT_CALL(*app_, performinteraction_choice_set_map()).Times(0);
+    EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+        .WillOnce(Return(choice_set_id));
+    EXPECT_CALL(*app_, is_perform_interaction_active()).WillOnce(Return(false));
+    EXPECT_CALL(*app_, performinteraction_choice_set_map()).Times(0);
 
-  EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
-      .WillOnce(Return(choice_set_id));
+    EXPECT_CALL(*app_, FindChoiceSet(kChoiceSetId))
+        .WillOnce(Return(choice_set_id));
 
-  EXPECT_CALL(*app_, app_id())
-      .WillOnce(Return(kConnectionKey))
-      .WillOnce(Return(kConnectionKey));
-  EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
-  EXPECT_CALL(*app_, UpdateHash());
+    EXPECT_CALL(*app_, app_id())
+        .WillOnce(Return(kConnectionKey))
+        .WillOnce(Return(kConnectionKey));
+    EXPECT_CALL(*app_, RemoveChoiceSet(kChoiceSetId));
+    EXPECT_CALL(*app_, UpdateHash());
+  }
+  EXPECT_CALL(app_mngr_, GetRPCService())
+      .Times(2)
+      .WillRepeatedly(ReturnRef(rpc_service_));
+  EXPECT_CALL(rpc_service_, ManageHMICommand(_)).WillOnce(Return(true));
+  EXPECT_CALL(rpc_service_, ManageMobileCommand(_, _));
 
   DeleteInteractionChoiceSetRequestPtr command =
       CreateCommand<DeleteInteractionChoiceSetRequest>(message_);

--- a/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/on_button_notification_commands_test.cc
@@ -132,8 +132,7 @@ TYPED_TEST(OnButtonNotificationCommandsTest,
 
   SharedPtr<Notification> command(
       this->template CreateCommand<Notification>(notification_msg));
-  EXPECT_CALL(this->app_mngr_, GetRPCService())
-      .WillOnce(ReturnRef(this->rpc_service_));
+  EXPECT_CALL(this->app_mngr_, GetRPCService()).Times(0);
   EXPECT_CALL(this->rpc_service_, SendMessageToMobile(_, _)).Times(0);
 
   command->Run();

--- a/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
+++ b/src/components/application_manager/test/commands/mobile/simple_response_commands_test.cc
@@ -192,6 +192,7 @@ TEST_F(ScrollableMessageResponseTest, Run_SUCCESS) {
   SharedPtr<am::commands::ScrollableMessageResponse> command(
       CreateCommand<am::commands::ScrollableMessageResponse>(message));
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(app));
+  ON_CALL(app_mngr_, GetRPCService()).WillByDefault(ReturnRef(rpc_service_));
   EXPECT_CALL(*app, UnsubscribeFromSoftButtons(_));
   command->Run();
 }

--- a/src/components/application_manager/test/commands/mobile/subscribe_button_request_test.cc
+++ b/src/components/application_manager/test/commands/mobile/subscribe_button_request_test.cc
@@ -184,8 +184,11 @@ TEST_F(SubscribeButtonRequestTest, Run_SUCCESS) {
   EXPECT_CALL(rpc_service_, ManageHMICommand(_))
       .WillOnce(DoAll(SaveArg<0>(&hmi_result_msg), Return(true)));
 
-  MessageSharedPtr mobile_result_msg(
-      CatchMobileCommandResult(CallRun(*command)));
+  MessageSharedPtr mobile_result_msg;
+  EXPECT_CALL(this->rpc_service_, ManageMobileCommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&mobile_result_msg), Return(true)));
+  ASSERT_TRUE(command->Init());
+  command->Run();
 
   EXPECT_EQ(hmi_apis::FunctionID::Buttons_OnButtonSubscription,
             static_cast<hmi_apis::FunctionID::eType>(


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR fixed unit test coverage for `get_urls_test.cc`, `sdl_activate_app_request_test.cc`, `alert_request_test.cc`,  `create_interaction_choice_set_test.cc`, `delete_interaction_choice_set_test.cc`, `on_button_notification_commands_test.cc`, `simple_response_commands_test.cc` and `subscribe_button_request_test.cc` units

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)